### PR TITLE
fix: node shell lang env

### DIFF
--- a/pkg/apiserver/authorization/rbac/rbac.go
+++ b/pkg/apiserver/authorization/rbac/rbac.go
@@ -90,7 +90,6 @@ func (r *ruleAccumulator) visit(_ fmt.Stringer, _ string, rule *rbacv1.PolicyRul
 
 func (r *RBACAuthorizer) Authorize(requestAttributes authorizer.Attributes) (authorizer.Decision, string, error) {
 	ruleCheckingVisitor := &authorizingVisitor{requestAttributes: requestAttributes}
-	klog.V(0).Infof("enter rbac authorize")
 
 	r.visitRulesFor(requestAttributes, ruleCheckingVisitor.visit)
 
@@ -203,13 +202,11 @@ func (r *RBACAuthorizer) rulesFor(requestAttributes authorizer.Attributes) ([]rb
 func (r *RBACAuthorizer) visitRulesFor(requestAttributes authorizer.Attributes, visitor func(source fmt.Stringer, regoPolicy string, rule *rbacv1.PolicyRule, err error) bool) {
 
 	if globalRoleBindings, err := r.am.ListGlobalRoleBindings(""); err != nil {
-		klog.V(0).Infof("ListGlobalRoleBindings: err=%v", err)
 		if !visitor(nil, "", nil, err) {
 			return
 		}
 	} else {
 		sourceDescriber := &globalRoleBindingDescriber{}
-		klog.V(0).Infof("globalRoleBindings:len: %d", len(globalRoleBindings))
 		for _, globalRoleBinding := range globalRoleBindings {
 			subjectIndex, applies := appliesTo(requestAttributes.GetUser(), globalRoleBinding.Subjects, "")
 			if !applies {

--- a/pkg/models/terminal/terminal.go
+++ b/pkg/models/terminal/terminal.go
@@ -248,6 +248,16 @@ func (n *NodeTerminaler) getNSEnterPod() (*v1.Pod, error) {
 						SecurityContext: &v1.SecurityContext{
 							Privileged: &n.Privileged,
 						},
+						Env: []v1.EnvVar{
+							{
+								Name:  "LANG",
+								Value: "en_US.UTF-8",
+							},
+							{
+								Name:  "LC_ALL",
+								Value: "en_US.UTF-8",
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
