### PR TITLE
fix: lldap users groups api

### DIFF
--- a/pkg/kapis/iam/v1alpha2/handler.go
+++ b/pkg/kapis/iam/v1alpha2/handler.go
@@ -205,6 +205,24 @@ func (h *iamHandler) ListUsers(request *restful.Request, response *restful.Respo
 	response.WriteEntity(result)
 }
 
+func (h *iamHandler) ListLLdapUsers(request *restful.Request, response *restful.Response) {
+	result, err := h.im.ListLLdapUsers(query.New())
+	if err != nil {
+		api.HandleInternalError(response, request, err)
+		return
+	}
+	response.WriteEntity(result)
+}
+
+func (h *iamHandler) ListLLdapGroups(request *restful.Request, response *restful.Response) {
+	result, err := h.im.ListLLdapGroups(query.New())
+	if err != nil {
+		api.HandleInternalError(response, request, err)
+		return
+	}
+	response.WriteEntity(result)
+}
+
 func appendGlobalRoleAnnotation(user *iamv1alpha2.User, globalRole string) *iamv1alpha2.User {
 	if user.Annotations == nil {
 		user.Annotations = make(map[string]string, 0)

--- a/pkg/kapis/iam/v1alpha2/register.go
+++ b/pkg/kapis/iam/v1alpha2/register.go
@@ -54,6 +54,7 @@ func AddToContainer(container *restful.Container, im im.IdentityManagementInterf
 		Returns(http.StatusOK, api.StatusOK, iamv1alpha2.User{}).
 		Reads(iamv1alpha2.User{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.UserTag}))
+
 	ws.Route(ws.DELETE("/users/{user}").
 		To(handler.DeleteUser).
 		Doc("Delete the specified user.").
@@ -78,6 +79,16 @@ func AddToContainer(container *restful.Container, im im.IdentityManagementInterf
 		To(handler.ListUsers).
 		Doc("List all users.").
 		Returns(http.StatusOK, api.StatusOK, api.ListResult{Items: []interface{}{iamv1alpha2.User{}}}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.UserTag}))
+
+	ws.Route(ws.GET("/lldap/users").
+		To(handler.ListLLdapUsers).
+		Doc("List all users sync to lldap").
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.UserTag}))
+
+	ws.Route(ws.GET("/lldap/groups").
+		To(handler.ListLLdapGroups).
+		Doc("List all groups sync to lldap").
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.UserTag}))
 
 	// clusterroles

--- a/pkg/models/iam/im/im.go
+++ b/pkg/models/iam/im/im.go
@@ -38,6 +38,8 @@ type IdentityManagementInterface interface {
 	UpdateUser(user *iamv1alpha2.User) (*iamv1alpha2.User, error)
 	DescribeUser(username string) (*iamv1alpha2.User, error)
 	ModifyPassword(username string, password string) error
+	ListLLdapUsers(query *query.Query) (*api.ListResult, error)
+	ListLLdapGroups(query *query.Query) (*api.ListResult, error)
 }
 
 func NewOperator(ksClient kubesphere.Interface, userGetter resources.Interface) IdentityManagementInterface {
@@ -46,6 +48,14 @@ func NewOperator(ksClient kubesphere.Interface, userGetter resources.Interface) 
 		userGetter: userGetter,
 	}
 	return im
+}
+
+const syncToLLdapKey = "iam.kubesphere.io/sync-to-lldap"
+
+type LLdapUser struct {
+	Username string   `json:"username"`
+	Email    string   `json:"email"`
+	Groups   []string `json:"groups"`
 }
 
 type imOperator struct {
@@ -113,6 +123,54 @@ func (im *imOperator) ListUsers(query *query.Query) (result *api.ListResult, err
 		items = append(items, out)
 	}
 	result.Items = items
+	return result, nil
+}
+func (im *imOperator) ListLLdapUsers(query *query.Query) (*api.ListResult, error) {
+	result := new(api.ListResult)
+	users, err := im.userGetter.List("", query)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+	items := make([]interface{}, 0)
+	for _, item := range users.Items {
+		user := item.(*iamv1alpha2.User)
+		// filter user that do not sync to lldap
+		if user.Annotations[syncToLLdapKey] != "true" {
+			continue
+		}
+		if len(user.Spec.Groups) == 0 {
+			user.Spec.Groups = make([]string, 0)
+		}
+
+		out := LLdapUser{Username: user.Name, Email: user.Spec.Email, Groups: user.Spec.Groups}
+		items = append(items, out)
+	}
+	result.Items = items
+	result.TotalItems = len(items)
+	return result, nil
+}
+
+func (im *imOperator) ListLLdapGroups(query *query.Query) (*api.ListResult, error) {
+	result := new(api.ListResult)
+	users, err := im.userGetter.List("", query)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+	items := make([]interface{}, 0)
+	for _, item := range users.Items {
+		user := item.(*iamv1alpha2.User)
+		// filter user that do not sync to lldap
+		if user.Annotations[syncToLLdapKey] != "true" {
+			continue
+		}
+		for i := range user.Spec.Groups {
+			items = append(items, user.Spec.Groups[i])
+		}
+	}
+	result.Items = items
+	result.TotalItems = len(items)
 	return result, nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
