### PR TITLE
fix: change cronjobs gv from v1beta1 to v1

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -339,6 +339,7 @@ func (s *APIServer) waitForResourceSync(ctx context.Context) error {
 		},
 		{Group: "batch", Version: "v1"}: {
 			"jobs",
+			"cronjobs",
 		},
 		//{Group: "batch", Version: "v1beta1"}: {
 		//	"cronjobs",

--- a/pkg/models/resources/v1alpha2/cronjob/cronjobs.go
+++ b/pkg/models/resources/v1alpha2/cronjob/cronjobs.go
@@ -19,7 +19,7 @@ package cronjob
 import (
 	"sort"
 
-	"k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/client-go/informers"
 
 	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha2"
@@ -37,17 +37,17 @@ func NewCronJobSearcher(informer informers.SharedInformerFactory) v1alpha2.Inter
 }
 
 func (c *cronJobSearcher) Get(namespace, name string) (interface{}, error) {
-	return c.informer.Batch().V1beta1().CronJobs().Lister().CronJobs(namespace).Get(name)
+	return c.informer.Batch().V1().CronJobs().Lister().CronJobs(namespace).Get(name)
 }
 
-func cronJobStatus(item *v1beta1.CronJob) string {
+func cronJobStatus(item *batchv1.CronJob) string {
 	if item.Spec.Suspend != nil && *item.Spec.Suspend {
 		return v1alpha2.StatusPaused
 	}
 	return v1alpha2.StatusRunning
 }
 
-func (*cronJobSearcher) match(match map[string]string, item *v1beta1.CronJob) bool {
+func (*cronJobSearcher) match(match map[string]string, item *batchv1.CronJob) bool {
 	for k, v := range match {
 		switch k {
 		case v1alpha2.Status:
@@ -63,7 +63,7 @@ func (*cronJobSearcher) match(match map[string]string, item *v1beta1.CronJob) bo
 	return true
 }
 
-func (*cronJobSearcher) fuzzy(fuzzy map[string]string, item *v1beta1.CronJob) bool {
+func (*cronJobSearcher) fuzzy(fuzzy map[string]string, item *batchv1.CronJob) bool {
 
 	for k, v := range fuzzy {
 		if !v1alpha2.ObjectMetaFuzzyMath(k, v, item.ObjectMeta) {
@@ -74,7 +74,7 @@ func (*cronJobSearcher) fuzzy(fuzzy map[string]string, item *v1beta1.CronJob) bo
 	return true
 }
 
-func (*cronJobSearcher) compare(left, right *v1beta1.CronJob, orderBy string) bool {
+func (*cronJobSearcher) compare(left, right *batchv1.CronJob, orderBy string) bool {
 	switch orderBy {
 	case v1alpha2.LastScheduleTime:
 		if left.Status.LastScheduleTime == nil {
@@ -90,13 +90,13 @@ func (*cronJobSearcher) compare(left, right *v1beta1.CronJob, orderBy string) bo
 }
 
 func (c *cronJobSearcher) Search(namespace string, conditions *params.Conditions, orderBy string, reverse bool) ([]interface{}, error) {
-	cronJobs, err := c.informer.Batch().V1beta1().CronJobs().Lister().CronJobs(namespace).List(labels.Everything())
+	cronJobs, err := c.informer.Batch().V1().CronJobs().Lister().CronJobs(namespace).List(labels.Everything())
 
 	if err != nil {
 		return nil, err
 	}
 
-	result := make([]*v1beta1.CronJob, 0)
+	result := make([]*batchv1.CronJob, 0)
 
 	if len(conditions.Match) == 0 && len(conditions.Fuzzy) == 0 {
 		result = cronJobs


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
