### PR TITLE
feat: add some node metric

### DIFF
--- a/pkg/models/monitoring/named_metrics.go
+++ b/pkg/models/monitoring/named_metrics.go
@@ -137,6 +137,12 @@ var NodeMetrics = []string{
 	"node_disk_power_on_hours",
 	"node_one_disk_data_bytes_written",
 	"node_one_disk_data_bytes_read",
+	"node_cpu_info",
+	"node_memory_buffer_bytes",
+	"node_memory_cached_bytes",
+	"node_memory_system_reserved",
+	"node_vmstat_pswpout_bytes",
+	"node_vmstat_pswpin_bytes",
 
 	"node_device_size_usage",
 	"node_device_size_utilisation",

--- a/pkg/simple/client/monitoring/prometheus/promql.go
+++ b/pkg/simple/client/monitoring/prometheus/promql.go
@@ -128,6 +128,12 @@ var promQLTemplates = map[string]string{
 	"node_disk_power_on_hours":          `node:node_disk_power_on_hours{$1}`,
 	"node_one_disk_data_bytes_written":  `node:node_one_disk_data_bytes_written{$1}`,
 	"node_one_disk_data_bytes_read":     `node:node_one_disk_data_bytes_read{$1}`,
+	"node_cpu_info":                     `node:node_cpu_info{$1}`,
+	"node_memory_buffer_bytes":          `node:node_memory_Buffers_bytes{$1}`,
+	"node_memory_cached_bytes":          `node:node_memory_Cached_bytes{$1}`,
+	"node_memory_system_reserved":       `node:node_memory_system_reserved{$1}`,
+	"node_vmstat_pswpout_bytes":         `node:node_vmstat_pswpout{$1}`,
+	"node_vmstat_pswpin_bytes":          `node:node_vmstat_pswpin{$1}`,
 
 	"node_device_size_usage":       `sum by(device, node, host_ip, role) (node_filesystem_size_bytes{device!~"/dev/loop\\d+",device=~"/dev/.*",job="node-exporter"} * on(namespace, pod) group_left(node, host_ip, role) node_namespace_pod:kube_pod_info:{$1}) - sum by(device, node, host_ip, role) (node_filesystem_avail_bytes{device!~"/dev/loop\\d+",device=~"/dev/.*",job="node-exporter"} * on(namespace, pod) group_left(node, host_ip, role) node_namespace_pod:kube_pod_info:{$1})`,
 	"node_device_size_utilisation": `1 - sum by(device, node, host_ip, role) (node_filesystem_avail_bytes{device!~"/dev/loop\\d+",device=~"/dev/.*",job="node-exporter"} * on(namespace, pod) group_left(node, host_ip, role) node_namespace_pod:kube_pod_info:{$1}) / sum by(device, node, host_ip, role) (node_filesystem_size_bytes{device!~"/dev/loop\\d+",device=~"/dev/.*",job="node-exporter"} * on(namespace, pod) group_left(node, host_ip, role) node_namespace_pod:kube_pod_info:{$1})`,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
