### PR TITLE
fix: change some namespace

### DIFF
--- a/pkg/apiserver/authentication/authenticators/lldap/jwt.go
+++ b/pkg/apiserver/authentication/authenticators/lldap/jwt.go
@@ -29,7 +29,7 @@ func (j *jwtAuthenticator) AuthenticateToken(ctx context.Context, tokenString st
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
-		secret, err := j.secretLister.Secrets("os-system").Get("lldap-credentials")
+		secret, err := j.secretLister.Secrets("os-framework").Get("lldap-credentials")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -127,7 +127,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 
 		lldapClient, err := lclient.New(&lconfig.Config{
-			Host:       "http://lldap-service.os-system:17170",
+			Host:       "http://lldap-service.os-framework:17170",
 			Username:   bindUsername,
 			Password:   bindPassword,
 			TokenCache: memory.New(),
@@ -246,7 +246,7 @@ func (r *Reconciler) syncUserStatus(ctx context.Context, user *iamv1alpha2.User)
 
 func (r *Reconciler) getCredentialVal(ctx context.Context, key string) (string, error) {
 	var secret corev1.Secret
-	k := types.NamespacedName{Name: "lldap-credentials", Namespace: "os-system"}
+	k := types.NamespacedName{Name: "lldap-credentials", Namespace: "os-framework"}
 	err := r.Client.Get(ctx, k, &secret)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
