### PR TITLE
feat: add cpu power metric

### DIFF
--- a/pkg/models/monitoring/named_metrics.go
+++ b/pkg/models/monitoring/named_metrics.go
@@ -153,6 +153,10 @@ var NodeMetrics = []string{
 	"node_rapl_core_joules_power",
 	"node_disk_lsblk_info",
 
+	"node_rapl_constraint_0_power_limit_uw",
+	"node_rapl_constraint_0_max_power_uw",
+	"node_rapl_constraint_1_power_limit_uw",
+
 	// meter
 	"meter_node_cpu_usage",
 	"meter_node_memory_usage_wo_cache",

--- a/pkg/simple/client/monitoring/prometheus/promql.go
+++ b/pkg/simple/client/monitoring/prometheus/promql.go
@@ -118,6 +118,11 @@ var promQLTemplates = map[string]string{
 	"node_rapl_core_joules_power":`sum by (node) (rate(node:node_rapl_core_joules_power{job="node-exporter"}[5m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{})`,
 	"node_disk_lsblk_info": `node:node_disk_lsblk_info{$1}`,
 
+	"node_rapl_constraint_0_power_limit_uw": `node_rapl_constraint_0_power_limit_uw{$1}`,
+	"node_rapl_constraint_0_max_power_uw": `node_rapl_constraint_0_max_power_uw{$1}`,
+	"node_rapl_constraint_1_power_limit_uw": `node_rapl_constraint_1_power_limit_uw{$1}`,
+
+
 	"node_disk_smartctl_info":           `node:node_disk_smartctl_info{$1}`,
 	"node_disk_temp_celsius":            `node:node_disk_temp_celsius{$1}`,
 	"node_cpu_temp_celsius":             `node:node_cpu_temp_celsius{$1}`,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
