### PR TITLE
fix: add post method for naemspace metrics

### DIFF
--- a/pkg/kapis/monitoring/v1alpha3/handler.go
+++ b/pkg/kapis/monitoring/v1alpha3/handler.go
@@ -261,3 +261,23 @@ func (h handler) handleNamespaceMetricsQuery(req *restful.Request, resp *restful
 	}
 	h.handleNamedMetricsQuery(resp, opt)
 }
+
+func (h handler) handleNamespaceMetricsQueryPost(req *restful.Request, resp *restful.Response) {
+	params, err := parseNamespaceMetricsRequest(req)
+	if err != nil {
+		api.HandleBadRequest(resp, nil, err)
+		return
+	}
+	opt, err := h.makeQueryOptions(params, monitoring.LevelNamespace)
+	if err != nil {
+		if err.Error() == ErrNoHit {
+			res := handleNoHit(opt.namedMetrics)
+			resp.WriteAsJson(res)
+			return
+		}
+
+		api.HandleBadRequest(resp, nil, err)
+		return
+	}
+	h.handleNamedMetricsQuery(resp, opt)
+}

--- a/pkg/kapis/monitoring/v1alpha3/helper.go
+++ b/pkg/kapis/monitoring/v1alpha3/helper.go
@@ -125,6 +125,49 @@ func (q queryOptions) shouldSort() bool {
 	return q.target != "" && q.identifier != ""
 }
 
+// NamespaceMetricsRequest is the JSON body accepted by the POST
+// `/namespaces` endpoint. It carries the same information that used to
+// be passed as query parameters on the GET version of the route.
+type NamespaceMetricsRequest struct {
+	MetricsFilter   string `json:"metrics_filter,omitempty"`
+	ResourcesFilter string `json:"resources_filter,omitempty"`
+	Start           string `json:"start,omitempty"`
+	End             string `json:"end,omitempty"`
+	Step            string `json:"step,omitempty"`
+	Time            string `json:"time,omitempty"`
+	SortMetric      string `json:"sort_metric,omitempty"`
+	SortType        string `json:"sort_type,omitempty"`
+	Page            string `json:"page,omitempty"`
+	Limit           string `json:"limit,omitempty"`
+}
+
+// parseNamespaceMetricsRequest reads the POST body of the namespace metrics
+// endpoint and merges it with the path parameters extracted from the URL.
+// An empty body is tolerated so that callers can rely on defaults.
+func parseNamespaceMetricsRequest(req *restful.Request) (reqParams, error) {
+	var body NamespaceMetricsRequest
+	if req.Request != nil && req.Request.ContentLength != 0 {
+		if err := req.ReadEntity(&body); err != nil && err != io.EOF {
+			return reqParams{}, err
+		}
+	}
+
+	r := reqParams{
+		time:           body.Time,
+		start:          body.Start,
+		end:            body.End,
+		step:           body.Step,
+		target:         body.SortMetric,
+		order:          body.SortType,
+		page:           body.Page,
+		limit:          body.Limit,
+		metricFilter:   body.MetricsFilter,
+		resourceFilter: body.ResourcesFilter,
+		namespaceName:  req.PathParameter("namespace"),
+	}
+	return r, nil
+}
+
 func parseRequestParams(req *restful.Request) reqParams {
 	var r reqParams
 	r.time = req.QueryParameter("time")

--- a/pkg/kapis/monitoring/v1alpha3/register.go
+++ b/pkg/kapis/monitoring/v1alpha3/register.go
@@ -193,6 +193,16 @@ func AddToContainer(c *restful.Container, k8sClient kubernetes.Interface, monito
 		Returns(http.StatusOK, respOK, model.Metrics{})).
 		Produces(restful.MIME_JSON)
 
+	ws.Route(ws.POST("/namespaces").
+		To(h.handleNamespaceMetricsQueryPost).
+		Doc("Get namespace-level metric data of all namespaces. Query parameters are passed in the JSON request body.").
+		Consumes(restful.MIME_JSON).
+		Reads(NamespaceMetricsRequest{}).
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.NamespaceMetricsTag}).
+		Writes(model.Metrics{}).
+		Returns(http.StatusOK, respOK, model.Metrics{})).
+		Produces(restful.MIME_JSON)
+
 	ws.Route(ws.GET("/namespaces/{namespace}/workloads/{kind}/{workload}/pods").
 		To(h.handlePodMetricsQuery).
 		Doc("Get pod-level metric data of a specific workload's pods. Navigate to the workload by the namespace.").


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
